### PR TITLE
feat: walk deeply nested selector expressions

### DIFF
--- a/looppointer.go
+++ b/looppointer.go
@@ -159,13 +159,7 @@ func getIdentity(expr ast.Expr) *ast.Ident {
 	switch typed := expr.(type) {
 	case *ast.SelectorExpr:
 		// Get parent identity; i.e. `a` of the `a.b`.
-		parent, ok := typed.X.(*ast.Ident)
-		if !ok {
-			return nil
-		}
-		// NOTE: If that is descendants member like `a.b.c`,
-		//       typed.X will be `*ast.SelectorExpr`.
-		return parent
+		return selectorRoot(typed)
 
 	case *ast.Ident:
 		// Get simple identity; i.e. `a` of the `a`.
@@ -173,6 +167,18 @@ func getIdentity(expr ast.Expr) *ast.Ident {
 			return nil
 		}
 		return typed
+	}
+	return nil
+}
+
+func selectorRoot(selector *ast.SelectorExpr) *ast.Ident {
+	var exp ast.Expr = selector
+	// climb up the SelectorExpr until the root is reached
+	for typed, ok := exp.(*ast.SelectorExpr); ok; typed, ok = exp.(*ast.SelectorExpr) {
+		exp = typed.X
+	}
+	if id, ok := exp.(*ast.Ident); ok {
+		return id
 	}
 	return nil
 }

--- a/looppointer_test.go
+++ b/looppointer_test.go
@@ -12,4 +12,5 @@ func Test(t *testing.T) {
 	analysistest.Run(t, testdata, looppointer.Analyzer, "simple")
 	analysistest.Run(t, testdata, looppointer.Analyzer, "fixed")
 	analysistest.Run(t, testdata, looppointer.Analyzer, "nolint")
+	analysistest.Run(t, testdata, looppointer.Analyzer, "nested")
 }

--- a/testdata/src/nested/nested.go
+++ b/testdata/src/nested/nested.go
@@ -1,0 +1,33 @@
+package main
+
+type A struct {
+	b B
+}
+type B struct {
+	c C
+}
+type C struct {
+	d int
+}
+
+func NewA(value int) A {
+	return A{B{C{value}}}
+}
+
+func main() {
+	var intSlice []*int
+
+	println("loop expecting 1, 2, 3, 4")
+	for _, p := range []A{NewA(1), NewA(2), NewA(3), NewA(4)} {
+		intSlice = append(intSlice, &p.b.c.d) // want "taking a pointer for the loop variable p"
+	}
+
+	println(`slice expecting "1, 2, 3, 4" but "4, 4, 4, 4"`)
+	for _, p := range intSlice {
+		printp(p)
+	}
+}
+
+func printp(p *int) {
+	println(*p)
+}


### PR DESCRIPTION
Hello! I like this project a lot. I'm planning on using a fork of it for a [data analysis project](https://github.com/github-vet/bots) I'm running against go repositories on GitHub.

As part of the changes I'm making, I've enabled the analysis to search through arbitrarily nested SelectorExpr nodes. Please find the changes along with an additional test included as part of the PR.

Thanks for making a great tool!