### PR TITLE
fix: rare nil panic; occasionally id.Obj can be nil

### DIFF
--- a/looppointer.go
+++ b/looppointer.go
@@ -141,7 +141,7 @@ func (s *Searcher) checkUnaryExpr(n *ast.UnaryExpr, stack []ast.Node) (*ast.Iden
 
 	// Get identity of the referred item
 	id := getIdentity(n.X)
-	if id == nil {
+	if id == nil || id.Obj == nil {
 		return nil, token.NoPos, true
 	}
 


### PR DESCRIPTION
I'm not sure if this happens from the command-line, but when running the analysis from code one may encounter cases where `id.Obj` is nil (as documented). This may cause a runtime panic.

I suspect when `id.Obj == nil` we have nothing to report, which is what this PR does.

Feel free to close if you have another way to resolve.